### PR TITLE
Parametrize darknet proxy hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2023-10-26
+
+### Changed
+
+  - Introduced command line settings to parametrize TOR proxy and I2P SAM router
+    addresses and ports: `--tor-proxy-{host,port}` and `--i2p-sam-{host,port}`
+
 ## [2.1.3] - 2023-10-26
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "p2p-crawler"
-version = "2.1.3"
+version = "2.2.0"
 description = "Crawler for Bitcoin's P2P network"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/p2p_crawler/config.py
+++ b/src/p2p_crawler/config.py
@@ -119,11 +119,32 @@ class ResultSettings(ComponentSettings):
 
 
 @dataclass
+class NetworkSettings(ComponentSettings):
+    """Settings related to networking."""
+
+    tor_proxy_host: str
+    tor_proxy_port: str
+    i2p_sam_host: str
+    i2p_sam_port: str
+
+    @classmethod
+    def parse(cls, args):
+        """Create class instance from arguments."""
+        return cls(
+            tor_proxy_host=args.tor_proxy_host,
+            tor_proxy_port=args.tor_proxy_port,
+            i2p_sam_host=args.i2p_sam_host,
+            i2p_sam_port=args.i2p_sam_port,
+        )
+
+
+@dataclass
 class NodeSettings(ComponentSettings):
     """Settings for nodes."""
 
     timeouts: dict[str, TimeoutSettings]
     getaddr_retries: int
+    network_settings: NetworkSettings
 
     @classmethod
     def parse(cls, args):
@@ -131,6 +152,7 @@ class NodeSettings(ComponentSettings):
         return cls(
             timeouts=TimeoutSettings.parse(args),
             getaddr_retries=args.getaddr_retries,
+            network_settings=NetworkSettings.parse(args),
         )
 
 
@@ -228,6 +250,34 @@ def add_general_args(parser):
         type=int,
         default=os.environ.get("GETADDR_RETRIES", 2),
         help="Number of retries for getaddr requests for reachable nodes",
+    )
+
+    parser.add_argument(
+        "--tor-proxy-host",
+        type=str,
+        default="127.0.0.1",
+        help="SOCKS5 proxy host for Tor",
+    )
+
+    parser.add_argument(
+        "--tor-proxy-port",
+        type=int,
+        default=9050,
+        help="SOCKS5 proxy port for Tor",
+    )
+
+    parser.add_argument(
+        "--i2p-sam-host",
+        type=str,
+        default="127.0.0.1",
+        help="SAM router host for I2P",
+    )
+
+    parser.add_argument(
+        "--i2p-sam-port",
+        type=int,
+        default=7656,
+        help="SAM router port for I2P",
     )
 
     parser.add_argument(

--- a/src/p2p_crawler/node.py
+++ b/src/p2p_crawler/node.py
@@ -27,7 +27,7 @@ class Node:
     @cached_property
     def _socket(self) -> Socket:
         """Lazy-create socket."""
-        return Socket()
+        return Socket(self.settings.network_settings)
 
     @cached_property
     def _timeouts(self) -> TimeoutSettings:


### PR DESCRIPTION
The existing docker setup used dedicated docker instances for the TOR and I2PD daemons; the host names of those instances were hardcoded into the crawler. Since the NixOS setup will run TOR and I2PD natively, those hard-coded host names need to change.

Instead of changing the hard-coded addresses to 127.0.0.1, they are parametrized -- as are the corresponding ports.