### PR TITLE
Fix bug with addr message parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2023-11-27
+
+### Changed
+
+  - Fix bug during parsing of addr messages
+
 ## [3.1.4] - 2023-11-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "p2p-crawler"
-version = "3.1.4"
+version = "3.1.5"
 description = "Crawler for Bitcoin's P2P network"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/p2p_crawler/protocol.py
+++ b/src/p2p_crawler/protocol.py
@@ -357,8 +357,14 @@ class AddrMessage:
     addresses: list[Address]
 
     @classmethod
-    def parse(cls, s, version):
-        """Deserialize 'addr' message."""
+    def parse(cls, s):
+        """
+        Deserialize 'addr' message.
+
+        In theory, the node version is required to determine whether address
+        records contain a timestamp or not (version >= 31402), but since nodes
+        that old are no longer around, timestamps are assumed implicitly.
+        """
         try:
             num_addresses = VarInt.decode(s)
         except asyncio.IncompleteReadError:
@@ -367,7 +373,7 @@ class AddrMessage:
 
         addresses = []
         for _ in range(num_addresses):
-            timestamp = int.from_bytes(s.read(4), "little") if version >= 31402 else 0
+            timestamp = int.from_bytes(s.read(4), "little")
             _ = s.read(8)
             ip = IPv6Address(s.read(16))
             ip_str = str(ip.ipv4_mapped) if ip.ipv4_mapped else str(ip)


### PR DESCRIPTION
In theory, addr v1 messages need to be differentiated by node version. Very old nodes do not provide timestamps with address records in their addr messages, so the parse() function expected a version argument, which was not provided (bug!). Instead of providing the version, it is assumed that all nodes' versions are recent enough and addr messages provide timestamps (which is true in practice).