### PR TITLE
Log nodes that did not complete handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2023-12-05
+
+### Changed
+
+  - Log nodes to which a connection could be established but which did not complete the
+    handshake, and introduce `handshake_successful` field in the reachable nodes log to
+    differentiate between nodes that successfully completed the handshake and those that
+    did not.
+
 ## [3.3.0] - 2023-12-04
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "p2p-crawler"
-version = "3.3.0"
+version = "3.4.0"
 description = "Crawler for Bitcoin's P2P network"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/p2p_crawler/node.py
+++ b/src/p2p_crawler/node.py
@@ -205,7 +205,6 @@ class Node:
           - receiver_ip and receiver_port: crawler's address
           - sender_services: duplicate of services
           - sender_ip and sender_port: often set to zero, duplicate of address
-          - handshake_successful: always true for reachable nodes
           - nonce: random number
         """
         stats = {
@@ -219,6 +218,7 @@ class Node:
             "handshake_timestamp",
             "time_connect",
             "handshake_attempts",
+            "handshake_successful",
             "handshake_duration",
             "version",
             "services",
@@ -241,5 +241,5 @@ class Node:
             elif stat.startswith("advertised_addrs_"):
                 stats[stat] = self.stats.get(stat, 0)
             else:
-                stats[stat] = self.stats[stat]
+                stats[stat] = self.stats.get(stat, None)
         return stats


### PR DESCRIPTION
For some research, it is useful to log nodes to which a connection could be established but that did not complete the handshake.

Examples:
- nodes whose message thread was temporarily overloaded
- nodes configured to resist crawlers
- malicious nodes