### PR TITLE
Add support to record node's address replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2024-05-06
+
+### Changed
+
+  - Add support to log addresses received in `addr` messages on a per-peer basis. This
+    new feature is enabled via the `--record-addr-data` command-line argument.
+  - Obsolete the `--record-addr-stats` option to collect timestamps for all advertised
+    addresses since this data can be extracted from the data collected using the newly
+    introduced `--record-addr-data` option.
+
 ## [3.4.0] - 2023-12-05
 
 ### Changed

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       };
 
       devShells.default = pkgs.mkShell {
-        packages = [ pkgs.poetry ];
+        packages = [ pkgs.poetry pkgs.python39 ];
       };
     });
 }

--- a/module.nix
+++ b/module.nix
@@ -99,7 +99,7 @@ in
 
       store-debug-log = mkEnableOption "storing the debug log" // { default = true; };
 
-      record-addr-stats = mkEnableOption "collecting and storing address statistics";
+      record-addr-data = mkEnableOption "collecting and storing addr data on a per-node basis";
 
       gcs = {
         enable = mkEnableOption "storing to GCS";
@@ -238,7 +238,7 @@ in
           --log-level ${cfg.log-level} \
           --result-path ${cfg.result-path} \
           ${if cfg.store-debug-log then "--store-debug-log" else "--no-store-debug-log"} \
-          ${if cfg.record-addr-stats then "--record-addr-stats" else "--no-record-addr-stats"} \
+          ${if cfg.record-addr-data then "--record-addr-data" else "--no-record-addr-data"} \
           ${if cfg.gcs.enable
 then "--store-to-gcs ${optionalString (cfg.gcs.bucket != null) "--gcs-bucket ${cfg.gcs.bucket}"} ${optionalString (cfg.gcs.location != null) "--gcs-location ${cfg.gcs.location}"} ${optionalString (cfg.gcs.credentials != null) "--gcs-credentials ${cfg.gcs.credentials}"}"
 else "--no-store-to-gcs"} \

--- a/poetry.lock
+++ b/poetry.lock
@@ -391,6 +391,98 @@ files = [
 ]
 
 [[package]]
+name = "mmh3"
+version = "4.1.0"
+description = "Python extension for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
+optional = false
+python-versions = "*"
+files = [
+    {file = "mmh3-4.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:be5ac76a8b0cd8095784e51e4c1c9c318c19edcd1709a06eb14979c8d850c31a"},
+    {file = "mmh3-4.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:98a49121afdfab67cd80e912b36404139d7deceb6773a83620137aaa0da5714c"},
+    {file = "mmh3-4.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5259ac0535874366e7d1a5423ef746e0d36a9e3c14509ce6511614bdc5a7ef5b"},
+    {file = "mmh3-4.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5950827ca0453a2be357696da509ab39646044e3fa15cad364eb65d78797437"},
+    {file = "mmh3-4.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1dd0f652ae99585b9dd26de458e5f08571522f0402155809fd1dc8852a613a39"},
+    {file = "mmh3-4.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99d25548070942fab1e4a6f04d1626d67e66d0b81ed6571ecfca511f3edf07e6"},
+    {file = "mmh3-4.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53db8d9bad3cb66c8f35cbc894f336273f63489ce4ac416634932e3cbe79eb5b"},
+    {file = "mmh3-4.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75da0f615eb55295a437264cc0b736753f830b09d102aa4c2a7d719bc445ec05"},
+    {file = "mmh3-4.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b926b07fd678ea84b3a2afc1fa22ce50aeb627839c44382f3d0291e945621e1a"},
+    {file = "mmh3-4.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c5b053334f9b0af8559d6da9dc72cef0a65b325ebb3e630c680012323c950bb6"},
+    {file = "mmh3-4.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:5bf33dc43cd6de2cb86e0aa73a1cc6530f557854bbbe5d59f41ef6de2e353d7b"},
+    {file = "mmh3-4.1.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:fa7eacd2b830727ba3dd65a365bed8a5c992ecd0c8348cf39a05cc77d22f4970"},
+    {file = "mmh3-4.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:42dfd6742b9e3eec599f85270617debfa0bbb913c545bb980c8a4fa7b2d047da"},
+    {file = "mmh3-4.1.0-cp310-cp310-win32.whl", hash = "sha256:2974ad343f0d39dcc88e93ee6afa96cedc35a9883bc067febd7ff736e207fa47"},
+    {file = "mmh3-4.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:74699a8984ded645c1a24d6078351a056f5a5f1fe5838870412a68ac5e28d865"},
+    {file = "mmh3-4.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:f0dc874cedc23d46fc488a987faa6ad08ffa79e44fb08e3cd4d4cf2877c00a00"},
+    {file = "mmh3-4.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3280a463855b0eae64b681cd5b9ddd9464b73f81151e87bb7c91a811d25619e6"},
+    {file = "mmh3-4.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:97ac57c6c3301769e757d444fa7c973ceb002cb66534b39cbab5e38de61cd896"},
+    {file = "mmh3-4.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a7b6502cdb4dbd880244818ab363c8770a48cdccecf6d729ade0241b736b5ec0"},
+    {file = "mmh3-4.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52ba2da04671a9621580ddabf72f06f0e72c1c9c3b7b608849b58b11080d8f14"},
+    {file = "mmh3-4.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a5fef4c4ecc782e6e43fbeab09cff1bac82c998a1773d3a5ee6a3605cde343e"},
+    {file = "mmh3-4.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5135358a7e00991f73b88cdc8eda5203bf9de22120d10a834c5761dbeb07dd13"},
+    {file = "mmh3-4.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cff9ae76a54f7c6fe0167c9c4028c12c1f6de52d68a31d11b6790bb2ae685560"},
+    {file = "mmh3-4.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6f02576a4d106d7830ca90278868bf0983554dd69183b7bbe09f2fcd51cf54f"},
+    {file = "mmh3-4.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:073d57425a23721730d3ff5485e2da489dd3c90b04e86243dd7211f889898106"},
+    {file = "mmh3-4.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:71e32ddec7f573a1a0feb8d2cf2af474c50ec21e7a8263026e8d3b4b629805db"},
+    {file = "mmh3-4.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7cbb20b29d57e76a58b40fd8b13a9130db495a12d678d651b459bf61c0714cea"},
+    {file = "mmh3-4.1.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:a42ad267e131d7847076bb7e31050f6c4378cd38e8f1bf7a0edd32f30224d5c9"},
+    {file = "mmh3-4.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4a013979fc9390abadc445ea2527426a0e7a4495c19b74589204f9b71bcaafeb"},
+    {file = "mmh3-4.1.0-cp311-cp311-win32.whl", hash = "sha256:1d3b1cdad7c71b7b88966301789a478af142bddcb3a2bee563f7a7d40519a00f"},
+    {file = "mmh3-4.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:0dc6dc32eb03727467da8e17deffe004fbb65e8b5ee2b502d36250d7a3f4e2ec"},
+    {file = "mmh3-4.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:9ae3a5c1b32dda121c7dc26f9597ef7b01b4c56a98319a7fe86c35b8bc459ae6"},
+    {file = "mmh3-4.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0033d60c7939168ef65ddc396611077a7268bde024f2c23bdc283a19123f9e9c"},
+    {file = "mmh3-4.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d6af3e2287644b2b08b5924ed3a88c97b87b44ad08e79ca9f93d3470a54a41c5"},
+    {file = "mmh3-4.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d82eb4defa245e02bb0b0dc4f1e7ee284f8d212633389c91f7fba99ba993f0a2"},
+    {file = "mmh3-4.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba245e94b8d54765e14c2d7b6214e832557e7856d5183bc522e17884cab2f45d"},
+    {file = "mmh3-4.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb04e2feeabaad6231e89cd43b3d01a4403579aa792c9ab6fdeef45cc58d4ec0"},
+    {file = "mmh3-4.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e3b1a27def545ce11e36158ba5d5390cdbc300cfe456a942cc89d649cf7e3b2"},
+    {file = "mmh3-4.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce0ab79ff736d7044e5e9b3bfe73958a55f79a4ae672e6213e92492ad5e734d5"},
+    {file = "mmh3-4.1.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b02268be6e0a8eeb8a924d7db85f28e47344f35c438c1e149878bb1c47b1cd3"},
+    {file = "mmh3-4.1.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:deb887f5fcdaf57cf646b1e062d56b06ef2f23421c80885fce18b37143cba828"},
+    {file = "mmh3-4.1.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:99dd564e9e2b512eb117bd0cbf0f79a50c45d961c2a02402787d581cec5448d5"},
+    {file = "mmh3-4.1.0-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:08373082dfaa38fe97aa78753d1efd21a1969e51079056ff552e687764eafdfe"},
+    {file = "mmh3-4.1.0-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:54b9c6a2ea571b714e4fe28d3e4e2db37abfd03c787a58074ea21ee9a8fd1740"},
+    {file = "mmh3-4.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a7b1edf24c69e3513f879722b97ca85e52f9032f24a52284746877f6a7304086"},
+    {file = "mmh3-4.1.0-cp312-cp312-win32.whl", hash = "sha256:411da64b951f635e1e2284b71d81a5a83580cea24994b328f8910d40bed67276"},
+    {file = "mmh3-4.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bebc3ecb6ba18292e3d40c8712482b4477abd6981c2ebf0e60869bd90f8ac3a9"},
+    {file = "mmh3-4.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:168473dd608ade6a8d2ba069600b35199a9af837d96177d3088ca91f2b3798e3"},
+    {file = "mmh3-4.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:372f4b7e1dcde175507640679a2a8790185bb71f3640fc28a4690f73da986a3b"},
+    {file = "mmh3-4.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:438584b97f6fe13e944faf590c90fc127682b57ae969f73334040d9fa1c7ffa5"},
+    {file = "mmh3-4.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6e27931b232fc676675fac8641c6ec6b596daa64d82170e8597f5a5b8bdcd3b6"},
+    {file = "mmh3-4.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:571a92bad859d7b0330e47cfd1850b76c39b615a8d8e7aa5853c1f971fd0c4b1"},
+    {file = "mmh3-4.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a69d6afe3190fa08f9e3a58e5145549f71f1f3fff27bd0800313426929c7068"},
+    {file = "mmh3-4.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afb127be0be946b7630220908dbea0cee0d9d3c583fa9114a07156f98566dc28"},
+    {file = "mmh3-4.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:940d86522f36348ef1a494cbf7248ab3f4a1638b84b59e6c9e90408bd11ad729"},
+    {file = "mmh3-4.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3dcccc4935686619a8e3d1f7b6e97e3bd89a4a796247930ee97d35ea1a39341"},
+    {file = "mmh3-4.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01bb9b90d61854dfc2407c5e5192bfb47222d74f29d140cb2dd2a69f2353f7cc"},
+    {file = "mmh3-4.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:bcb1b8b951a2c0b0fb8a5426c62a22557e2ffc52539e0a7cc46eb667b5d606a9"},
+    {file = "mmh3-4.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:6477a05d5e5ab3168e82e8b106e316210ac954134f46ec529356607900aea82a"},
+    {file = "mmh3-4.1.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:da5892287e5bea6977364b15712a2573c16d134bc5fdcdd4cf460006cf849278"},
+    {file = "mmh3-4.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:99180d7fd2327a6fffbaff270f760576839dc6ee66d045fa3a450f3490fda7f5"},
+    {file = "mmh3-4.1.0-cp38-cp38-win32.whl", hash = "sha256:9b0d4f3949913a9f9a8fb1bb4cc6ecd52879730aab5ff8c5a3d8f5b593594b73"},
+    {file = "mmh3-4.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:598c352da1d945108aee0c3c3cfdd0e9b3edef74108f53b49d481d3990402169"},
+    {file = "mmh3-4.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:475d6d1445dd080f18f0f766277e1237fa2914e5fe3307a3b2a3044f30892103"},
+    {file = "mmh3-4.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5ca07c41e6a2880991431ac717c2a049056fff497651a76e26fc22224e8b5732"},
+    {file = "mmh3-4.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ebe052fef4bbe30c0548d12ee46d09f1b69035ca5208a7075e55adfe091be44"},
+    {file = "mmh3-4.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaefd42e85afb70f2b855a011f7b4d8a3c7e19c3f2681fa13118e4d8627378c5"},
+    {file = "mmh3-4.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac0ae43caae5a47afe1b63a1ae3f0986dde54b5fb2d6c29786adbfb8edc9edfb"},
+    {file = "mmh3-4.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6218666f74c8c013c221e7f5f8a693ac9cf68e5ac9a03f2373b32d77c48904de"},
+    {file = "mmh3-4.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ac59294a536ba447b5037f62d8367d7d93b696f80671c2c45645fa9f1109413c"},
+    {file = "mmh3-4.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:086844830fcd1e5c84fec7017ea1ee8491487cfc877847d96f86f68881569d2e"},
+    {file = "mmh3-4.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e42b38fad664f56f77f6fbca22d08450f2464baa68acdbf24841bf900eb98e87"},
+    {file = "mmh3-4.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d08b790a63a9a1cde3b5d7d733ed97d4eb884bfbc92f075a091652d6bfd7709a"},
+    {file = "mmh3-4.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:73ea4cc55e8aea28c86799ecacebca09e5f86500414870a8abaedfcbaf74d288"},
+    {file = "mmh3-4.1.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:f90938ff137130e47bcec8dc1f4ceb02f10178c766e2ef58a9f657ff1f62d124"},
+    {file = "mmh3-4.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:aa1f13e94b8631c8cd53259250556edcf1de71738936b60febba95750d9632bd"},
+    {file = "mmh3-4.1.0-cp39-cp39-win32.whl", hash = "sha256:a3b680b471c181490cf82da2142029edb4298e1bdfcb67c76922dedef789868d"},
+    {file = "mmh3-4.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:fefef92e9c544a8dbc08f77a8d1b6d48006a750c4375bbcd5ff8199d761e263b"},
+    {file = "mmh3-4.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:8e2c1f6a2b41723a4f82bd5a762a777836d29d664fc0095f17910bea0adfd4a6"},
+    {file = "mmh3-4.1.0.tar.gz", hash = "sha256:a1cf25348b9acd229dda464a094d6170f47d2850a1fcb762a3b6172d2ce6ca4a"},
+]
+
+[package.extras]
+test = ["mypy (>=1.0)", "pytest (>=7.0.0)"]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -571,4 +663,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.10"
-content-hash = "37dfd46eb74151e3aa097d9241bff9f8f9dfd74aa29c7e252f6ad44f4cb6c723"
+content-hash = "e7799333082d02e91b3d82e456d894392f52a12bed88ff9aa1abdc16a86b367f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "p2p-crawler"
-version = "3.4.0"
+version = "3.5.0"
 description = "Crawler for Bitcoin's P2P network"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"
@@ -12,6 +12,7 @@ i2plib = "^0.0.14"
 pytest = "^7.4.2"
 google-cloud-storage = "^2.12.0"
 python-socks = {extras = ["asyncio"], version = "^2.4.3"}
+mmh3 = "^4.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/p2p_crawler/config.py
+++ b/src/p2p_crawler/config.py
@@ -119,7 +119,7 @@ class ResultSettings(ComponentSettings):
     path: Path
     reachable_nodes: Path
     crawler_stats: Path
-    address_stats: Path
+    addr_data: Path
     gcs: GCSSettings
 
     @classmethod
@@ -130,7 +130,7 @@ class ResultSettings(ComponentSettings):
             path=Path(args.result_path),
             reachable_nodes=Path(f"{prefix}_reachable_nodes.csv"),
             crawler_stats=Path(f"{prefix}_crawler_stats.json"),
-            address_stats=Path(f"{prefix}_address_stats.json"),
+            addr_data=Path(f"{prefix}_addr_data.dat"),
             gcs=GCSSettings.parse(args),
         )
 
@@ -183,7 +183,7 @@ class CrawlerSettings(ComponentSettings):
     delay_start: int
     num_workers: int
     node_share: float
-    record_addr_stats: bool
+    record_addr_data: bool
     node_settings: NodeSettings
     result_settings: ResultSettings
 
@@ -195,7 +195,7 @@ class CrawlerSettings(ComponentSettings):
             delay_start=args.delay_start,
             num_workers=args.num_workers,
             node_share=args.node_share,
-            record_addr_stats=args.record_addr_stats,
+            record_addr_data=args.record_addr_data,
             node_settings=NodeSettings.parse(args),
             result_settings=ResultSettings.parse(args),
         )
@@ -338,10 +338,10 @@ def add_general_args(parser):
     )
 
     parser.add_argument(
-        "--record-addr-stats",
+        "--record-addr-data",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Record and store address statistics",
+        help="Record addr data received on a per-peer basis",
     )
 
     parser.add_argument(

--- a/src/p2p_crawler/protocol.py
+++ b/src/p2p_crawler/protocol.py
@@ -408,7 +408,8 @@ class AddrV2Message:
             return socket.inet_ntop(socket.AF_INET, addr_data)
 
         if addr_type == "ipv6":
-            return socket.inet_ntop(socket.AF_INET6, addr_data)
+            ip = IPv6Address(addr_data)
+            return str(ip.ipv4_mapped) if ip.ipv4_mapped else str(ip)
 
         if addr_type == "torv2":
             permanent_id = addr_data

--- a/tools/addr_data_decoder.py
+++ b/tools/addr_data_decoder.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+"""Decode addr data from a p2p-address-data file."""
+
+import argparse
+import io
+import lzma
+import os
+import time
+from dataclasses import dataclass, field
+from functools import cached_property
+from pathlib import Path
+from typing import ClassVar, Optional
+
+
+@dataclass
+class Address:
+    """Class representing an address."""
+
+    id: int
+    last_seen: int
+    net_id: int
+
+    def __post_init__(self):
+        networks = ["ipv4", "ipv6", "onion_v2", "onion_v3", "i2p", "cjdns"]
+        if not 0 <= self.net_id < len(networks):
+            raise ValueError(f"Invalid network ID: {self.net_id}")
+        self.network = networks[self.net_id]
+
+    def __repr__(self):
+        return (
+            f"Address(id={self.id}, last_seen={self.last_seen}, network={self.network})"
+        )
+
+
+@dataclass
+class AddrData:
+    """Decoder for p2p-crawler address data."""
+
+    file: Path
+
+    _epoch_offset: Optional[int] = field(init=False, default=None)
+
+    HEADER_MAGIC: ClassVar[str] = "p2p-addr-data"
+    HEADER_VERSION: ClassVar[int] = 1
+    EOF_MARKER: ClassVar[bytes] = "EOF".encode("ASCII")
+
+    @cached_property
+    def _buf(self):
+        """Read and decompress input file."""
+        time_start = time.time()
+        with lzma.open(self.file, "rb") as f:
+            data = f.read()
+        elapsed = time.time() - time_start
+        print(f"Decompressed input file '{self.file}' in {elapsed:.2f}s.")
+        return io.BytesIO(data)
+
+    @staticmethod
+    def decode_zigzag(value: int) -> int:
+        """Decode ZigZag-encoded signed integer."""
+        return (value >> 1) ^ -(value & 1)
+
+    def eof(self):
+        """Check for end of file."""
+        maybe_eof_marker = self._buf.read(len(AddrData.EOF_MARKER))
+        if maybe_eof_marker != AddrData.EOF_MARKER:
+            self._buf.seek(-len(AddrData.EOF_MARKER), os.SEEK_CUR)
+            return False
+        print("Reached end of file.")
+        return True
+
+    def check_header(self):
+        """Read and verify file header."""
+        magic = self._buf.read(len(AddrData.HEADER_MAGIC)).decode("ASCII")
+        if magic != AddrData.HEADER_MAGIC:
+            raise ValueError(f"Invalid file magic: {magic}")
+
+        version = int.from_bytes(self._buf.read(1), "big")
+        if version != AddrData.HEADER_VERSION:
+            raise ValueError(f"Unsupported file version: {version}")
+
+        epoch = int.from_bytes(self._buf.read(4), "big")
+        self._epoch_offset = epoch
+
+        terminator = self._buf.read(1).decode("ASCII")
+        if terminator != "\n":
+            raise ValueError(f"Invalid header terminator: {terminator}")
+
+        print(f"read header (magic={magic}, version={version}, epoch={epoch})")
+
+    def read_varint(self) -> int:
+        """Read and decode variable length integer."""
+        shift = 0
+        result = 0
+        while True:
+            byte = self._buf.read(1)
+            if not byte:
+                raise IOError("Unexpected end of stream while reading varint")
+            byte = ord(byte)
+            result |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                break
+            shift += 7
+        return result
+
+    def decode(self):
+        """Decode input file."""
+        time_start = time.time()
+
+        self.check_header()
+
+        result = {}
+        while not self.eof():
+            node_len = self.read_varint()
+            node = self._buf.read(node_len).decode("ascii").strip()
+            result[node] = []
+
+            num_records = self.read_varint()
+            for i in range(num_records):
+                addr_net_id = self.read_varint()
+                addr_id = addr_net_id >> 3
+                net_id = addr_net_id & 0x07
+
+                lastseen_delta_zigzag = self.read_varint()
+                lastseen_delta = AddrData.decode_zigzag(lastseen_delta_zigzag)
+                lastseen = self._epoch_offset - lastseen_delta
+
+                result[node].append(Address(addr_id, lastseen, net_id))
+
+                if len(result) % 1000 == 0 and i == num_records - 1:
+                    elapsed = time.time() - time_start
+                    print(f"decoded={len(result)}, elapsed={elapsed:.1f}s")
+
+            if self._buf.read(1) != b"\n":
+                raise ValueError("Record not properly terminated with newline")
+
+        elapsed = time.time() - time_start
+        print(f"Finished decoding: total runtime {elapsed:.2f}s.")
+
+        return result
+
+
+def inspect(data: dict):
+    """Inspect data."""
+
+    for i, (node, addr_records) in enumerate(data.items()):
+        print(f"record={i}, node={node}, addr_recs=", end="")
+        for j in range(min(3, len(addr_records))):
+            print(f"{addr_records[j]}, ", end="")
+        print(" (cropped to at most three records)")
+
+
+def main():
+    """Main function."""
+    parser = argparse.ArgumentParser(
+        description="Decode and display contents of a binary file formatted with address hashes."
+    )
+    parser.add_argument("file", help="The path to the binary file to decode.")
+    args = parser.parse_args()
+
+    decoder = AddrData(Path(args.file))
+    data = decoder.decode()
+    inspect(data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allows recording of hashes of addresses (advertised in `addr` messages) on a per-peer bases using the `--record-addr-hashes` command-line argument.

Uses a binary output format to avoid large files.

Todos:
- [x] Support new argument in nix module
- [x] Test (staging)
- [x] Optimize size of output file
  - Output files too large (20k nodes x 1k addr replies x ~30B (mix of IPv4/IPv6/Onion/I2P) = 600MB)
  - [x] Use 32-bit MurmurHash3 hash of addresses
    - Upper-bound estimate: 20k nodes x 1k replies x 4B = 80MB
    - Empirical data from two runs: 69MB, 65MB
  - [x] Map 32-bit hashes onto integers (0 to `NUM_UNIQUE_HASHES`), so they can be efficiently encoded as varints (~2B instead of 32 bit)
    - Estimate: 20k nodes x 1k replies x ~2B = ~40MB
    - Empirical data from run: 50MB -> might be a lot more than 65536 addresses?
  - Include zigzag/varint-timestamp deltas (based on difference with epoch time when crawler is started) and include epoch used to create deltas in file header so seen_by times can be reconstructed
  - Include address network ids
  - [x] Evaluate LZMA on top of hashing
- [x] Add code to store new output to GCS
- [x] Test (staging)
  - [x] Test run
  - [x] Test decode script
- [ ] Deploy (prod)