### PR TITLE
Minor refactoring of history and node classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.7.1 - 2024-06-19
+
+- Refactor Node class to switch from passing static `NodeSettings` via the constructor
+  to using a class variable and method to initialize the settings once. This avoids
+  unnecessary piggybacking the settings throughout the code. Among other things, this
+  allows for some simplifications in the newly introduced `History` class.
+
 ## 3.7.0 - 2024-06-18
 
 - Support caching previously discovered node across runs and re-trying them in successive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "p2p-crawler"
-version = "3.7.0"
+version = "3.7.1"
 description = "Crawler for Bitcoin's P2P network"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/p2p_crawler/config.py
+++ b/src/p2p_crawler/config.py
@@ -131,7 +131,7 @@ class HistorySettings(ComponentSettings):
         return cls(
             enable=args.reachable_node_history,
             max_retries=args.reachable_node_history_max_retries,
-            path=Path(f"{args.result_path}/reachabe_nodes_history.json"),
+            path=Path(f"{args.result_path}/reachabe_nodes_history.json.bz2"),
         )
 
 

--- a/src/p2p_crawler/node.py
+++ b/src/p2p_crawler/node.py
@@ -7,6 +7,7 @@ import logging as log
 import time
 from dataclasses import asdict, dataclass, field
 from functools import cached_property
+from typing import ClassVar
 
 from .config import NodeSettings, TimeoutSettings
 from .decorators import timing
@@ -20,9 +21,21 @@ class Node:
     """Class representing Bitcoin nodes."""
 
     address: Address
-    settings: NodeSettings = field(repr=False)
     seed_distance: int = 0
     stats: dict[str, str | int | bool] = field(default_factory=dict)
+
+    # class variable, used for static settings set via command-line
+    settings: ClassVar[NodeSettings]
+
+    @staticmethod
+    def configure(settings: NodeSettings):
+        """Configure node settings."""
+        Node.settings = settings
+
+    def __post_init__(self):
+        """Ensure `configure` has been called."""
+        if not hasattr(self, "settings"):
+            raise RuntimeError("Node class not initialized via configure()")
 
     @cached_property
     def _socket(self) -> Socket:


### PR DESCRIPTION
Refactor `Node` class to switch from passing static `NodeSettings` via the constructor to using a class variable and method to initialize the settings once. This avoids unnecessary piggybacking the settings throughout the code.

Among other things, this allows for some simplifications in the newly introduced `History` class.